### PR TITLE
Convert tools package to Java

### DIFF
--- a/location/src/main/java/akhoi/libs/mlct/tools/java/ByteConcat.java
+++ b/location/src/main/java/akhoi/libs/mlct/tools/java/ByteConcat.java
@@ -58,7 +58,7 @@ public class ByteConcat {
                 }
                 content = Arrays.copyOf(content, capableSize);
             }
-            content[position] = (byte) (content[position] | (value << (32 - size) >>> (32 - remainder)));
+            content[position] = (byte) (content[position] | value << (32 - size) >>> (32 - remainder));
             int nextBytePos = posPartial + Math.min(size, remainder);
             position += nextBytePos >>> 3;
             posPartial = nextBytePos & 7;

--- a/location/src/main/java/akhoi/libs/mlct/tools/java/ByteConcat.java
+++ b/location/src/main/java/akhoi/libs/mlct/tools/java/ByteConcat.java
@@ -1,0 +1,73 @@
+package akhoi.libs.mlct.tools.java;
+
+import androidx.annotation.VisibleForTesting;
+
+import java.util.Arrays;
+
+public class ByteConcat {
+    private final Object lock = new Object();
+    private byte[] bucket;
+    private int byteIndex;
+    private int position;
+
+    public ByteConcat() {
+        this(2);
+    }
+
+    public ByteConcat(int initCap) {
+        int highest = Integer.highestOneBit(initCap);
+        bucket = new byte[highest];
+    }
+
+    public byte[] getContent() {
+        int length = byteIndex + ((position + 7) >>> 3);
+        return Arrays.copyOf(bucket, length);
+    }
+
+    public void appendInt(int value, int size) {
+        int actualSize = Math.max(Math.min(size, 32), 0);
+        if (actualSize == 0) {
+            return;
+        }
+        actualSize = appendHighestByte(value, actualSize, 8 - position);
+        actualSize = appendHighestByte(value, actualSize, 8);
+        actualSize = appendHighestByte(value, actualSize, 8);
+        actualSize = appendHighestByte(value, actualSize, 8);
+        appendHighestByte(value, actualSize, 8);
+    }
+
+    public void appendLong(long value, int size) {
+        if (size <= 32) {
+            appendInt((int) (value & 0xFFFFFFFFL), size);
+        } else {
+            appendInt((int) (value >>> 32), size - 32);
+            appendInt((int) (value & 0xFFFFFFFFL), 32);
+        }
+    }
+
+    private int appendHighestByte(int value, int size, int remainder) {
+        if (size <= 0) {
+            return size;
+        }
+        synchronized (lock) {
+            if (byteIndex == bucket.length) {
+                int capableSize = Math.max(bucket.length << 1, bucket.length | (bucket.length >>> 1));
+                if (capableSize < bucket.length) {
+                    throw new OutOfMemoryError("Bucket size overflow, current: " + bucket.length + ", next: " + capableSize);
+                }
+                bucket = Arrays.copyOf(bucket, capableSize);
+            }
+            int shifted = (value << (32 - size)) >>> (32 - remainder);
+            bucket[byteIndex] = (byte) (bucket[byteIndex] | shifted);
+            int nextBytePosition = position + Math.min(size, remainder);
+            byteIndex += nextBytePosition >>> 3;
+            position = nextBytePosition & 7;
+        }
+        return size - remainder;
+    }
+
+    @VisibleForTesting
+    public int getBucketSize() {
+        return bucket.length;
+    }
+}

--- a/location/src/main/java/akhoi/libs/mlct/tools/java/ByteConcat.java
+++ b/location/src/main/java/akhoi/libs/mlct/tools/java/ByteConcat.java
@@ -58,7 +58,7 @@ public class ByteConcat {
                 }
                 content = Arrays.copyOf(content, capableSize);
             }
-            content[position] = (byte) (content[position] | (value << (32 - size)) >>> (32 - remainder));
+            content[position] = (byte) (content[position] | ((value << (32 - size)) >>> (32 - remainder)));
             int nextBytePos = posPartial + Math.min(size, remainder);
             position += nextBytePos >>> 3;
             posPartial = nextBytePos & 7;

--- a/location/src/main/java/akhoi/libs/mlct/tools/java/ByteConcat.java
+++ b/location/src/main/java/akhoi/libs/mlct/tools/java/ByteConcat.java
@@ -58,7 +58,7 @@ public class ByteConcat {
                 }
                 content = Arrays.copyOf(content, capableSize);
             }
-            content[position] = (byte) (content[position] | ((value << (32 - size)) >>> (32 - remainder)));
+            content[position] = (byte) (content[position] | (value << (32 - size) >>> (32 - remainder)));
             int nextBytePos = posPartial + Math.min(size, remainder);
             position += nextBytePos >>> 3;
             posPartial = nextBytePos & 7;

--- a/location/src/main/java/akhoi/libs/mlct/tools/java/ByteConcatReader.java
+++ b/location/src/main/java/akhoi/libs/mlct/tools/java/ByteConcatReader.java
@@ -1,0 +1,81 @@
+package akhoi.libs.mlct.tools.java;
+
+public class ByteConcatReader {
+    private final byte[] content;
+    private int byteIndex;
+    private int position;
+
+    public ByteConcatReader(byte[] content) {
+        this.content = content;
+    }
+
+    public int readInt(int size) {
+        int remaining = Math.max(Math.min(size, 32), 0);
+        if (remaining == 0) {
+            return 0;
+        }
+        int remainder = 8 - position;
+        int readSize = Math.min(remaining, remainder);
+        int result = readByte(0, readSize, remainder);
+        remaining -= readSize;
+        if (remaining <= 0) {
+            return result;
+        }
+        readSize = Math.min(remaining, 8);
+        result = readByte(result, readSize, 8);
+        remaining -= readSize;
+        if (remaining <= 0) {
+            return result;
+        }
+        readSize = Math.min(remaining, 8);
+        result = readByte(result, readSize, 8);
+        remaining -= readSize;
+        if (remaining <= 0) {
+            return result;
+        }
+        readSize = Math.min(remaining, 8);
+        result = readByte(result, readSize, 8);
+        remaining -= readSize;
+        if (remaining <= 0) {
+            return result;
+        }
+        readSize = Math.min(remaining, 8);
+        return readByte(result, readSize, 8);
+    }
+
+    public long readLong(int size) {
+        if (size <= 32) {
+            long value = readInt(size);
+            return value & ((1L << size) - 1);
+        } else {
+            int msBitsCount = size - 32;
+            long msBits = readInt(msBitsCount) & ((1L << msBitsCount) - 1);
+            long lsBits = readInt(32) & 0xFFFFFFFFL;
+            return (msBits << 32) | lsBits;
+        }
+    }
+
+    public double readDouble(int size) {
+        long longValue = readLong(size);
+        return Double.longBitsToDouble(longValue);
+    }
+
+    public void reset() {
+        position = 0;
+    }
+
+    public void skip(int count) {
+        position += count;
+    }
+
+    private int readByte(int value, int size, int remainder) {
+        if (byteIndex >= content.length) {
+            return value;
+        }
+        int read = ((1 << size) - 1) & ((content[byteIndex] & 0xFF) >>> (remainder - size));
+        int nextBytePosition = position + size;
+        byteIndex += nextBytePosition >>> 3;
+        position = nextBytePosition & 7;
+        return (value << size) | read;
+    }
+}

--- a/location/src/main/java/akhoi/libs/mlct/tools/java/ByteConcatReader.java
+++ b/location/src/main/java/akhoi/libs/mlct/tools/java/ByteConcatReader.java
@@ -2,8 +2,8 @@ package akhoi.libs.mlct.tools.java;
 
 public class ByteConcatReader {
     private final byte[] content;
-    private int byteIndex;
     private int position;
+    private int posPartial;
 
     public ByteConcatReader(byte[] content) {
         this.content = content;
@@ -14,31 +14,36 @@ public class ByteConcatReader {
         if (remaining == 0) {
             return 0;
         }
-        int remainder = 8 - position;
+
+        int remainder = 8 - posPartial;
         int readSize = Math.min(remaining, remainder);
         int result = readByte(0, readSize, remainder);
         remaining -= readSize;
         if (remaining <= 0) {
             return result;
         }
+
         readSize = Math.min(remaining, 8);
         result = readByte(result, readSize, 8);
         remaining -= readSize;
         if (remaining <= 0) {
             return result;
         }
+
         readSize = Math.min(remaining, 8);
         result = readByte(result, readSize, 8);
         remaining -= readSize;
         if (remaining <= 0) {
             return result;
         }
+
         readSize = Math.min(remaining, 8);
         result = readByte(result, readSize, 8);
         remaining -= readSize;
         if (remaining <= 0) {
             return result;
         }
+
         readSize = Math.min(remaining, 8);
         return readByte(result, readSize, 8);
     }
@@ -48,10 +53,10 @@ public class ByteConcatReader {
             long value = readInt(size);
             return value & ((1L << size) - 1);
         } else {
-            int msBitsCount = size - 32;
-            long msBits = readInt(msBitsCount) & ((1L << msBitsCount) - 1);
-            long lsBits = readInt(32) & 0xFFFFFFFFL;
-            return (msBits << 32) | lsBits;
+            int msbCount = size - 32;
+            long msbs = readInt(msbCount) & ((1L << msbCount) - 1);
+            long lsbs = readInt(32) & 0xFFFFFFFFL;
+            return (msbs << 32) | lsbs;
         }
     }
 
@@ -61,21 +66,22 @@ public class ByteConcatReader {
     }
 
     public void reset() {
-        position = 0;
+        posPartial = 0;
     }
 
     public void skip(int count) {
-        position += count;
+        posPartial += count;
     }
 
     private int readByte(int value, int size, int remainder) {
-        if (byteIndex >= content.length) {
+        if (position >= content.length) {
             return value;
         }
-        int read = ((1 << size) - 1) & ((content[byteIndex] & 0xFF) >>> (remainder - size));
-        int nextBytePosition = position + size;
-        byteIndex += nextBytePosition >>> 3;
-        position = nextBytePosition & 7;
+
+        int read = ((1 << size) - 1) & (content[position] >>> (remainder - size));
+        int posNextByte = posPartial + size;
+        position += posNextByte >>> 3;
+        posPartial = posNextByte & 7;
         return (value << size) | read;
     }
 }

--- a/location/src/main/java/akhoi/libs/mlct/tools/java/FileNameProperties.java
+++ b/location/src/main/java/akhoi/libs/mlct/tools/java/FileNameProperties.java
@@ -1,0 +1,47 @@
+package akhoi.libs.mlct.tools.java;
+
+import java.io.File;
+
+import kotlinx.coroutines.flow.Flow;
+import kotlin.reflect.KClass;
+
+public class FileNameProperties implements KeyValuePreferences {
+    private final akhoi.libs.mlct.tools.FileNameProperties delegate;
+
+    public FileNameProperties(File propsDir) {
+        this.delegate = new akhoi.libs.mlct.tools.FileNameProperties(propsDir);
+    }
+
+    public FileNameProperties(File propsDir, FileWatcher keyWatcher) {
+        this.delegate = new akhoi.libs.mlct.tools.FileNameProperties(propsDir, keyWatcher.getDelegate());
+    }
+
+    @Override
+    public synchronized boolean contains(String key) {
+        return delegate.contains(key);
+    }
+
+    @Override
+    public synchronized void remove(String key) {
+        delegate.remove(key);
+    }
+
+    @Override
+    public synchronized <T> T get(String key, KClass<T> klazz) {
+        return delegate.get(key, klazz);
+    }
+
+    @Override
+    public <T> Flow<T> flowGet(String key, KClass<T> klazz) {
+        return delegate.flowGet(key, klazz);
+    }
+
+    @Override
+    public synchronized void set(String key, Object value) {
+        delegate.set(key, value);
+    }
+
+    public synchronized void clear() {
+        delegate.clear();
+    }
+}

--- a/location/src/main/java/akhoi/libs/mlct/tools/java/FileWatcher.java
+++ b/location/src/main/java/akhoi/libs/mlct/tools/java/FileWatcher.java
@@ -1,0 +1,93 @@
+package akhoi.libs.mlct.tools.java;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.FileSystems;
+import java.nio.file.WatchService;
+
+import kotlinx.coroutines.flow.Flow;
+import kotlinx.coroutines.flow.FlowKt;
+import kotlin.Unit;
+import kotlin.coroutines.Continuation;
+import kotlin.jvm.functions.Function2;
+
+public class FileWatcher {
+    private final akhoi.libs.mlct.tools.FileWatcher delegate;
+
+    public FileWatcher(File rootDir) throws IOException {
+        this(rootDir, FileSystems.getDefault().newWatchService());
+    }
+
+    public FileWatcher(File rootDir, WatchService watchService) {
+        this.delegate = new akhoi.libs.mlct.tools.FileWatcher(rootDir, watchService);
+    }
+
+    akhoi.libs.mlct.tools.FileWatcher getDelegate() {
+        return delegate;
+    }
+
+    public Flow<EventData> watchFile(String key) {
+        Flow<akhoi.libs.mlct.tools.FileWatcher.EventData> flow = delegate.watchFile(key);
+        return FlowKt.map(flow, new Function2<akhoi.libs.mlct.tools.FileWatcher.EventData, Continuation<? super EventData>, Object>() {
+            @Override
+            public Object invoke(akhoi.libs.mlct.tools.FileWatcher.EventData eventData, Continuation<? super EventData> continuation) {
+                return new EventData(eventData);
+            }
+        });
+    }
+
+    public void unwatchFile(String key) {
+        delegate.unwatchFile(key);
+    }
+
+    public boolean registerDirectory(String key) {
+        return delegate.registerDirectory(key);
+    }
+
+    public void unregisterDirectory(String key) {
+        delegate.unregisterDirectory(key);
+    }
+
+    public Object start(Continuation<? super Unit> continuation) {
+        return delegate.start(continuation);
+    }
+
+    public void stop() {
+        delegate.stop();
+    }
+
+    public enum EventType {
+        CREATED,
+        DELETED,
+        UPDATED
+    }
+
+    public static final class EventData {
+        private final akhoi.libs.mlct.tools.FileWatcher.EventData delegate;
+
+        public EventData(akhoi.libs.mlct.tools.FileWatcher.EventData delegate) {
+            this.delegate = delegate;
+        }
+
+        public EventType getType() {
+            akhoi.libs.mlct.tools.FileWatcher.EventType type = delegate.getType();
+            switch (type) {
+                case CREATED:
+                    return EventType.CREATED;
+                case DELETED:
+                    return EventType.DELETED;
+                case UPDATED:
+                default:
+                    return EventType.UPDATED;
+            }
+        }
+
+        public java.nio.file.Path getPath() {
+            return delegate.getPath();
+        }
+
+        akhoi.libs.mlct.tools.FileWatcher.EventData getDelegate() {
+            return delegate;
+        }
+    }
+}

--- a/location/src/main/java/akhoi/libs/mlct/tools/java/FlowExt.java
+++ b/location/src/main/java/akhoi/libs/mlct/tools/java/FlowExt.java
@@ -1,0 +1,21 @@
+package akhoi.libs.mlct.tools.java;
+
+import kotlin.Unit;
+import kotlin.coroutines.Continuation;
+import kotlin.jvm.functions.Function2;
+import kotlinx.coroutines.CoroutineScope;
+import kotlinx.coroutines.Job;
+
+public final class FlowExt {
+    private FlowExt() {
+    }
+
+    public static Job flowTimer(
+            CoroutineScope scope,
+            long initialDelay,
+            long period,
+            Function2<? super CoroutineScope, ? super Continuation<? super Unit>, ? extends Object> action
+    ) {
+        return akhoi.libs.mlct.tools.FlowExtKt.flowTimer(scope, initialDelay, period, action);
+    }
+}

--- a/location/src/main/java/akhoi/libs/mlct/tools/java/KeyValuePreferences.java
+++ b/location/src/main/java/akhoi/libs/mlct/tools/java/KeyValuePreferences.java
@@ -1,0 +1,9 @@
+package akhoi.libs.mlct.tools.java;
+
+public interface KeyValuePreferences extends akhoi.libs.mlct.tools.KeyValuePreferences, KeyValuePrefsReader {
+    @Override
+    void set(String key, Object value);
+
+    @Override
+    void remove(String key);
+}

--- a/location/src/main/java/akhoi/libs/mlct/tools/java/KeyValuePrefsReader.java
+++ b/location/src/main/java/akhoi/libs/mlct/tools/java/KeyValuePrefsReader.java
@@ -1,0 +1,15 @@
+package akhoi.libs.mlct.tools.java;
+
+import kotlinx.coroutines.flow.Flow;
+import kotlin.reflect.KClass;
+
+public interface KeyValuePrefsReader extends akhoi.libs.mlct.tools.KeyValuePrefsReader {
+    @Override
+    <T> T get(String key, KClass<T> klazz);
+
+    @Override
+    <T> Flow<T> flowGet(String key, KClass<T> klazz);
+
+    @Override
+    boolean contains(String key);
+}

--- a/location/src/main/java/akhoi/libs/mlct/tools/java/KeyValuePrefsReaderExtensions.java
+++ b/location/src/main/java/akhoi/libs/mlct/tools/java/KeyValuePrefsReaderExtensions.java
@@ -1,0 +1,29 @@
+package akhoi.libs.mlct.tools.java;
+
+import kotlin.jvm.JvmClassMappingKt;
+import kotlin.reflect.KClass;
+
+public final class KeyValuePrefsReaderExtensions {
+    private KeyValuePrefsReaderExtensions() {
+    }
+
+    public static <T> T get(KeyValuePrefsReader reader, String key, KClass<T> kClass) {
+        return reader.get(key, kClass);
+    }
+
+    public static <T> T get(KeyValuePrefsReader reader, String key, Class<T> clazz) {
+        return reader.get(key, JvmClassMappingKt.getKotlinClass(clazz));
+    }
+
+    public static <T> boolean compare(KeyValuePrefsReader reader, String key, T value, KClass<T> kClass) {
+        T stored = reader.get(key, kClass);
+        if (value == null) {
+            return stored == null;
+        }
+        return value.equals(stored);
+    }
+
+    public static <T> boolean compare(KeyValuePrefsReader reader, String key, T value, Class<T> clazz) {
+        return compare(reader, key, value, JvmClassMappingKt.getKotlinClass(clazz));
+    }
+}

--- a/location/src/main/java/akhoi/libs/mlct/tools/java/ResizeDouble.java
+++ b/location/src/main/java/akhoi/libs/mlct/tools/java/ResizeDouble.java
@@ -5,22 +5,67 @@ public final class ResizeDouble {
     }
 
     public static long compressDouble(double number, int desExpSize, int desSigSize) {
-        return akhoi.libs.mlct.tools.ResizeDoubleKt.compressDouble(number, desExpSize, desSigSize);
+        long bits = Double.doubleToRawLongBits(number);
+        return resizeDouble(bits, 11, 52, desExpSize, desSigSize);
     }
 
     public static double expandDouble(long source, int srcExpSize, int srcSigSize) {
-        return akhoi.libs.mlct.tools.ResizeDoubleKt.expandDouble(source, srcExpSize, srcSigSize);
+        long resized = resizeDouble(source, srcExpSize, srcSigSize, 11, 52);
+        return Double.longBitsToDouble(resized);
     }
 
     public static long resizeDouble(long src) {
-        return akhoi.libs.mlct.tools.ResizeDoubleKt.resizeDouble(src, 11, 52, 11, 52);
+        return resizeDouble(src, 11, 52, 11, 52);
     }
 
     public static long resizeDouble(long src, int srcExpSize, int srcSigSize) {
-        return akhoi.libs.mlct.tools.ResizeDoubleKt.resizeDouble(src, srcExpSize, srcSigSize, 11, 52);
+        return resizeDouble(src, srcExpSize, srcSigSize, 11, 52);
     }
 
     public static long resizeDouble(long src, int srcExpSize, int srcSigSize, int desExpSize, int desSigSize) {
-        return akhoi.libs.mlct.tools.ResizeDoubleKt.resizeDouble(src, srcExpSize, srcSigSize, desExpSize, desSigSize);
+        int srcActualExpSize = clamp(srcExpSize, 0, 11);
+        int srcActualSigSize = clamp(srcSigSize, 1, 52);
+        int desActualExpSize = clamp(desExpSize, 0, 11);
+        int desActualSigSize = clamp(desSigSize, 1, 52);
+
+        long desExpMask = (desActualExpSize == 0) ? 0L : (1L << desActualExpSize) - 1L;
+        long desBias = desExpMask >> 1;
+        long desExponent;
+        if (desActualExpSize == 0) {
+            desExponent = 0L;
+        } else if (srcActualExpSize == 0) {
+            desExponent = (1L + desBias) & desExpMask;
+        } else {
+            long srcExpMask = (1L << srcActualExpSize) - 1L;
+            long srcBias = srcExpMask >> 1;
+            long srcExponent = (src >> srcActualSigSize) & srcExpMask;
+            if (srcExponent == 0L) {
+                desExponent = 0L;
+            } else if (srcExponent == srcExpMask) {
+                desExponent = desExpMask;
+            } else {
+                desExponent = (srcExponent - srcBias + desBias) & desExpMask;
+            }
+        }
+
+        long srcSignificandMask = (1L << srcActualSigSize) - 1L;
+        long desSignificandMask = (1L << desActualSigSize) - 1L;
+        long desSignificand = src & srcSignificandMask;
+        int shiftLeft = Math.max(desActualSigSize - srcActualSigSize, 0);
+        int shiftRight = Math.max(srcActualSigSize - desActualSigSize, 0);
+        if (shiftLeft > 0) {
+            desSignificand <<= shiftLeft;
+        }
+        if (shiftRight > 0) {
+            desSignificand >>>= shiftRight;
+        }
+        desSignificand &= desSignificandMask;
+
+        long desSign = (src >> (srcActualExpSize + srcActualSigSize)) & 1L;
+        return (desSign << desActualExpSize) | (desExponent << desActualSigSize) | desSignificand;
+    }
+
+    private static int clamp(int value, int min, int max) {
+        return Math.min(Math.max(value, min), max);
     }
 }

--- a/location/src/main/java/akhoi/libs/mlct/tools/java/ResizeDouble.java
+++ b/location/src/main/java/akhoi/libs/mlct/tools/java/ResizeDouble.java
@@ -47,6 +47,8 @@ public final class ResizeDouble {
         long desSignificand = (src & srcSignificandMask) << shiftLeft >> shiftRight & desSignificandMask;
 
         long desSign = (src >> (srcActualExpSize + srcActualSigSize)) & 1L;
-        return (desSign << desActualExpSize | desExponent) << desActualSigSize | desSignificand;
+        return (desSign << (desActualExpSize + desActualSigSize))
+                | (desExponent << desActualSigSize)
+                | desSignificand;
     }
 }

--- a/location/src/main/java/akhoi/libs/mlct/tools/java/ResizeDouble.java
+++ b/location/src/main/java/akhoi/libs/mlct/tools/java/ResizeDouble.java
@@ -47,8 +47,6 @@ public final class ResizeDouble {
         long desSignificand = (src & srcSignificandMask) << shiftLeft >> shiftRight & desSignificandMask;
 
         long desSign = (src >> (srcActualExpSize + srcActualSigSize)) & 1L;
-        return (desSign << (desActualExpSize + desActualSigSize))
-                | (desExponent << desActualSigSize)
-                | desSignificand;
+        return (desSign << desActualExpSize | desExponent) << desActualSigSize | desSignificand;
     }
 }

--- a/location/src/main/java/akhoi/libs/mlct/tools/java/ResizeDouble.java
+++ b/location/src/main/java/akhoi/libs/mlct/tools/java/ResizeDouble.java
@@ -1,0 +1,26 @@
+package akhoi.libs.mlct.tools.java;
+
+public final class ResizeDouble {
+    private ResizeDouble() {
+    }
+
+    public static long compressDouble(double number, int desExpSize, int desSigSize) {
+        return akhoi.libs.mlct.tools.ResizeDoubleKt.compressDouble(number, desExpSize, desSigSize);
+    }
+
+    public static double expandDouble(long source, int srcExpSize, int srcSigSize) {
+        return akhoi.libs.mlct.tools.ResizeDoubleKt.expandDouble(source, srcExpSize, srcSigSize);
+    }
+
+    public static long resizeDouble(long src) {
+        return akhoi.libs.mlct.tools.ResizeDoubleKt.resizeDouble(src, 11, 52, 11, 52);
+    }
+
+    public static long resizeDouble(long src, int srcExpSize, int srcSigSize) {
+        return akhoi.libs.mlct.tools.ResizeDoubleKt.resizeDouble(src, srcExpSize, srcSigSize, 11, 52);
+    }
+
+    public static long resizeDouble(long src, int srcExpSize, int srcSigSize, int desExpSize, int desSigSize) {
+        return akhoi.libs.mlct.tools.ResizeDoubleKt.resizeDouble(src, srcExpSize, srcSigSize, desExpSize, desSigSize);
+    }
+}

--- a/location/src/test/java/akhoi/libs/mlct/tools/java/ByteConcatReaderTest.java
+++ b/location/src/test/java/akhoi/libs/mlct/tools/java/ByteConcatReaderTest.java
@@ -1,0 +1,190 @@
+package akhoi.libs.mlct.tools.java;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class ByteConcatReaderTest {
+    @Test
+    public void testReadInt_zeroSize() {
+        byte[] content = new byte[]{0x77};
+        ByteConcatReader reader = new ByteConcatReader(content);
+        int actual = reader.readInt(0);
+        assertEquals(0, actual);
+    }
+
+    @Test
+    public void testReadInt_partialByte() {
+        byte[] content = new byte[]{0x77};
+        ByteConcatReader reader = new ByteConcatReader(content);
+        int actual = reader.readInt(5);
+        assertEquals(0x0E, actual);
+    }
+
+    @Test
+    public void testReadInt_fullByte() {
+        byte[] content = new byte[]{0x77, 0x33};
+        ByteConcatReader reader = new ByteConcatReader(content);
+        int actual = reader.readInt(8);
+        assertEquals(0x77, actual);
+    }
+
+    @Test
+    public void testReadInt_oneAndAPartialBytes() {
+        byte[] content = new byte[]{0x77, 0x33};
+        ByteConcatReader reader = new ByteConcatReader(content);
+        int actual = reader.readInt(15);
+        assertEquals(0x3B99, actual);
+    }
+
+    @Test
+    public void testReadInt_multipleBytes() {
+        byte[] content = new byte[]{0x77, 0x33, 0x11};
+        ByteConcatReader reader = new ByteConcatReader(content);
+        int actual = reader.readInt(16);
+        assertEquals(0x7733, actual);
+    }
+
+    @Test
+    public void testReadInt_fullInteger() {
+        byte[] content = new byte[]{0x77, 0x33, 0x11, 0x55, 0x00};
+        ByteConcatReader reader = new ByteConcatReader(content);
+        int actual = reader.readInt(32);
+        assertEquals(0x77331155, actual);
+    }
+
+    @Test
+    public void testReadInt_multipleReads() {
+        byte[] content = new byte[]{0x77, 0x33};
+        ByteConcatReader reader = new ByteConcatReader(content);
+        int firstRead = reader.readInt(5);
+        assertEquals(0x0E, firstRead);
+        int secondRead = reader.readInt(10);
+        assertEquals(0x399, secondRead);
+    }
+
+    @Test
+    public void testReset() {
+        byte[] content = new byte[]{0x77, 0x33};
+        ByteConcatReader reader = new ByteConcatReader(content);
+        int firstRead = reader.readInt(5);
+        assertEquals(0x0E, firstRead);
+        reader.reset();
+        int secondRead = reader.readInt(15);
+        assertEquals(0x3B99, secondRead);
+    }
+
+    @Test
+    public void testReadLong_full() {
+        ByteConcatReader reader = new ByteConcatReader(new byte[]{
+                0x2E, (byte) 0xF1, 0x02, 0x36,
+                (byte) 0xBD, 0x21, (byte) 0xFC, 0x77
+        });
+        long actual = reader.readLong(64);
+        assertEquals(0x2EF10236BD21FC77L, actual);
+    }
+
+    @Test
+    public void testReadLong_partial() {
+        ByteConcatReader reader = new ByteConcatReader(new byte[]{
+                0x2E, (byte) 0xF1, 0x02, 0x36,
+                (byte) 0xBD, 0x21, (byte) 0xFC, 0x77
+        });
+        long actual = reader.readLong(46);
+        assertEquals(0x0BBC408DAF48L, actual);
+    }
+
+    @Test
+    public void testReadLong_integerSize() {
+        ByteConcatReader reader = new ByteConcatReader(new byte[]{
+                0x2E, (byte) 0xF1, 0x02, 0x36,
+                (byte) 0xBD, 0x21, (byte) 0xFC, 0x77
+        });
+        long actual = reader.readLong(32);
+        assertEquals(0x2EF10236L, actual);
+    }
+
+    @Test
+    public void testReadLong_partialIntegerSize() {
+        ByteConcatReader reader = new ByteConcatReader(new byte[]{
+                0x2E, (byte) 0xF1, 0x02, 0x36,
+                (byte) 0xBD, 0x21, (byte) 0xFC, 0x77
+        });
+        long actual = reader.readLong(23);
+        assertEquals(0x177881L, actual);
+    }
+
+    @Test
+    public void testReadLong_zeroSize() {
+        ByteConcatReader reader = new ByteConcatReader(new byte[]{
+                0x2E, (byte) 0xF1, 0x02, 0x36,
+                (byte) 0xBD, 0x21, (byte) 0xFC, 0x77
+        });
+        long actual = reader.readLong(0);
+        assertEquals(0L, actual);
+    }
+
+    @Test
+    public void testReadLong_afterReadInt() {
+        ByteConcatReader reader = new ByteConcatReader(new byte[]{
+                0x02, 0x36, (byte) 0xBD, 0x21,
+                (byte) 0xFC, 0x77, (byte) 0xFA, 0x16
+        });
+        int intNum = reader.readInt(25);
+        long longNum = reader.readLong(32);
+        assertEquals(0x46D7AL, intNum);
+        assertEquals(0x43F8EFF4L, longNum);
+    }
+
+    @Test
+    public void testReadInt_afterReadLong() {
+        ByteConcatReader reader = new ByteConcatReader(new byte[]{
+                0x02, 0x36, (byte) 0xBD, 0x21,
+                (byte) 0xFC, 0x77, (byte) 0xFA, 0x16
+        });
+        long longNum = reader.readLong(32);
+        int intNum = reader.readInt(25);
+        assertEquals(0x236BD21L, longNum);
+        assertEquals(0x1F8EFF4, intNum);
+    }
+
+    @Test
+    public void testReadInt_exceededContentLength() {
+        ByteConcatReader reader = new ByteConcatReader(new byte[]{
+                0x62, 0x1F, (byte) 0xBC
+        });
+        int actual = reader.readInt(32);
+        assertEquals(0x621FBC, actual);
+    }
+
+    @Test
+    public void testReadLong_exceededNumberSize() {
+        ByteConcatReader reader = new ByteConcatReader(new byte[]{
+                0x62, 0x1F, (byte) 0xBC, (byte) 0xFF,
+                0x30, (byte) 0xAD, (byte) 0xFC, 0x14,
+                0x44, (byte) 0x95
+        });
+        long actual = reader.readLong(65);
+        assertEquals(0x621FBCFF30ADFC14L, actual);
+    }
+
+    @Test
+    public void testReadDouble() {
+        ByteConcatReader reader = new ByteConcatReader(new byte[]{
+                0x23, (byte) 0xFE, (byte) 0xB7, 0x09,
+                0x12, (byte) 0x98, (byte) 0xF1, (byte) 0xDC
+        });
+        double actual = reader.readDouble(64);
+        assertEquals(0x23FEB7091298F1DCL, Double.doubleToRawLongBits(actual));
+    }
+
+    @Test
+    public void testSkip() {
+        ByteConcatReader reader = new ByteConcatReader(new byte[]{0x23, (byte) 0xFE});
+        int firstRead = reader.readInt(4);
+        reader.skip(3);
+        long secondRead = reader.readLong(2);
+        assertEquals(0x2, firstRead);
+        assertEquals(0x3, secondRead);
+    }
+}

--- a/location/src/test/java/akhoi/libs/mlct/tools/java/ByteConcatTest.java
+++ b/location/src/test/java/akhoi/libs/mlct/tools/java/ByteConcatTest.java
@@ -118,7 +118,7 @@ public class ByteConcatTest {
         byteConcat.appendInt(0x22222222, 32);
         byte[] expected = new byte[]{0x22, 0x22, 0x22, 0x22};
         assertArrayEquals(expected, byteConcat.getContent());
-        assertEquals(4, byteConcat.getBucketSize());
+        assertEquals(4, byteConcat.getContentSize());
     }
 
     @Test
@@ -127,7 +127,7 @@ public class ByteConcatTest {
         byteConcat.appendInt(0x22222222, 32);
         byte[] expected = new byte[]{0x22, 0x22, 0x22, 0x22};
         assertArrayEquals(expected, byteConcat.getContent());
-        assertEquals(4, byteConcat.getBucketSize());
+        assertEquals(4, byteConcat.getContentSize());
     }
 
     @Test(expected = OutOfMemoryError.class)
@@ -239,6 +239,12 @@ public class ByteConcatTest {
         assertArrayEquals(new byte[]{
                 0x18, (byte) 0x96, 0x01, 0x47, 0x01, 0x63, 0x40, 0x04
         }, byteConcat.getContent());
-        assertEquals(8, byteConcat.getBucketSize());
+        assertEquals(8, byteConcat.getContentSize());
+    }
+
+    @Test
+    public void testConstructor_negativeInitCap() {
+        ByteConcat byteConcat = new ByteConcat(-15);
+        assertEquals(2, byteConcat.getContentSize());
     }
 }

--- a/location/src/test/java/akhoi/libs/mlct/tools/java/ByteConcatTest.java
+++ b/location/src/test/java/akhoi/libs/mlct/tools/java/ByteConcatTest.java
@@ -1,0 +1,244 @@
+package akhoi.libs.mlct.tools.java;
+
+import org.junit.Test;
+
+import java.util.Random;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+public class ByteConcatTest {
+    private static final Random RANDOM = new Random();
+
+    @Test
+    public void testAppendInt_positive_full() {
+        ByteConcat byteConcat = new ByteConcat(4);
+        byteConcat.appendInt(0x03A44718, 32);
+
+        byte[] expected = new byte[]{0x03, (byte) 0xA4, 0x47, 0x18};
+        assertArrayEquals(expected, byteConcat.getContent());
+    }
+
+    @Test
+    public void testAppendInt_positive_partial() {
+        ByteConcat byteConcat = new ByteConcat(1);
+        byteConcat.appendInt(0x18, 4);
+
+        byte[] expected = new byte[]{(byte) 0x80};
+        assertArrayEquals(expected, byteConcat.getContent());
+    }
+
+    @Test
+    public void testAppendInt_negative_partial() {
+        ByteConcat byteConcat = new ByteConcat(2);
+        byteConcat.appendInt(-0x4D2, 12);
+
+        byte[] expected = new byte[]{(byte) 0xB2, (byte) 0xE0};
+        assertArrayEquals(expected, byteConcat.getContent());
+    }
+
+    @Test
+    public void testAppendInt_negative_full() {
+        ByteConcat byteConcat = new ByteConcat(4);
+        byteConcat.appendInt(-0x03A44718, 32);
+
+        byte[] expected = new byte[]{(byte) 0xFC, 0x5B, (byte) 0xB8, (byte) 0xE8};
+        assertArrayEquals(expected, byteConcat.getContent());
+    }
+
+    @Test
+    public void testAppendInt_full_random() {
+        int count = RANDOM.nextInt(20);
+        for (int i = 0; i < count; i++) {
+            int value = RANDOM.nextInt();
+            ByteConcat byteConcat = new ByteConcat(4);
+            byteConcat.appendInt(value, 32);
+
+            byte[] expected = new byte[4];
+            for (int j = 0; j < 4; j++) {
+                expected[j] = (byte) (value >> ((3 - j) * 8));
+            }
+            assertArrayEquals(expected, byteConcat.getContent());
+        }
+    }
+
+    @Test
+    public void testAppendInt_multiple_partial_noRemainder() {
+        ByteConcat byteConcat = new ByteConcat(6);
+        byteConcat.appendInt(0x180, 8);
+        byteConcat.appendInt(0x1814C, 16);
+        byteConcat.appendInt(0x1A49168, 24);
+
+        byte[] expected = new byte[]{
+                (byte) 0x80, (byte) 0x81, 0x4C, (byte) 0xA4, (byte) 0x91, 0x68
+        };
+        assertArrayEquals(expected, byteConcat.getContent());
+    }
+
+    @Test
+    public void testAppendInt_multiple_partial_havingRemainder() {
+        ByteConcat byteConcat = new ByteConcat(8);
+        byteConcat.appendInt(0x39446, 12);
+        byteConcat.appendInt(0x35077C01, 20);
+        byteConcat.appendInt(0x29273C60, 28);
+
+        byte[] expected = new byte[]{
+                0x44, 0x67, 0x7C, 0x01,
+                (byte) 0x92, 0x73, (byte) 0xC6, 0x00
+        };
+        assertArrayEquals(expected, byteConcat.getContent());
+    }
+
+    @Test
+    public void testAppendInt_multiple_withinOneByte() {
+        ByteConcat byteConcat = new ByteConcat(1);
+        byteConcat.appendInt(1, 1);
+        byteConcat.appendInt(1, 1);
+        byteConcat.appendInt(1, 1);
+        assertArrayEquals(new byte[]{(byte) 0xE0}, byteConcat.getContent());
+    }
+
+    @Test
+    public void testAppendInt_zeroValueSize() {
+        ByteConcat byteConcat = new ByteConcat(3);
+        byteConcat.appendInt(0xC22A84, 0);
+        assertArrayEquals(new byte[0], byteConcat.getContent());
+    }
+
+    @Test
+    public void testAppendInt_negativeSize() {
+        ByteConcat byteConcat = new ByteConcat();
+        byteConcat.appendInt(0x01, -10);
+        assertArrayEquals(new byte[0], byteConcat.getContent());
+    }
+
+    @Test
+    public void testAppendInt_bucketExpanded() {
+        ByteConcat byteConcat = new ByteConcat(3);
+        byteConcat.appendInt(0x22222222, 32);
+        byte[] expected = new byte[]{0x22, 0x22, 0x22, 0x22};
+        assertArrayEquals(expected, byteConcat.getContent());
+        assertEquals(4, byteConcat.getBucketSize());
+    }
+
+    @Test
+    public void testAppendInt_bucketExpanded_multipleTimes() {
+        ByteConcat byteConcat = new ByteConcat(1);
+        byteConcat.appendInt(0x22222222, 32);
+        byte[] expected = new byte[]{0x22, 0x22, 0x22, 0x22};
+        assertArrayEquals(expected, byteConcat.getContent());
+        assertEquals(4, byteConcat.getBucketSize());
+    }
+
+    @Test(expected = OutOfMemoryError.class)
+    public void testAppendInt_bucketSizeTooLarge() {
+        ByteConcat byteConcat = new ByteConcat(1024);
+        while (true) {
+            byteConcat.appendInt(0x01, 32);
+        }
+    }
+
+    @Test
+    public void testAppendLong_multiple_withinOneByte() {
+        ByteConcat byteConcat = new ByteConcat(1);
+        byteConcat.appendLong(-0x01, 2);
+        byteConcat.appendLong(0x23, 2);
+        byteConcat.appendLong(0x45, 2);
+        assertArrayEquals(new byte[]{(byte) 0xF4}, byteConcat.getContent());
+    }
+
+    @Test
+    public void testAppendLong_full() {
+        ByteConcat byteConcat = new ByteConcat(8);
+        byteConcat.appendLong(0x1896014701634004L, 64);
+        assertArrayEquals(new byte[]{
+                0x18, (byte) 0x96, 0x01, 0x47, 0x01, 0x63, 0x40, 0x04
+        }, byteConcat.getContent());
+    }
+
+    @Test
+    public void testAppendLong_multiple_partial() {
+        ByteConcat byteConcat = new ByteConcat(11);
+        byteConcat.appendLong(0x1896014701634004L, 64);
+        byteConcat.appendLong(0x1896014701634004L, 24);
+        assertArrayEquals(new byte[]{
+                0x18, (byte) 0x96, 0x01, 0x47, 0x01, 0x63, 0x40, 0x04, 0x63, 0x40, 0x04
+        }, byteConcat.getContent());
+    }
+
+    @Test
+    public void testAppendLong_full_random() {
+        int count = RANDOM.nextInt(20);
+        for (int i = 0; i < count; i++) {
+            long value = RANDOM.nextLong();
+            ByteConcat byteConcat = new ByteConcat(8);
+            byteConcat.appendLong(value, 64);
+
+            byte[] expected = new byte[8];
+            for (int j = 0; j < 8; j++) {
+                expected[j] = (byte) (value >> ((7 - j) * 8));
+            }
+            assertArrayEquals(expected, byteConcat.getContent());
+        }
+    }
+
+    @Test
+    public void testAppendLong_positiveInteger_integerSize() {
+        ByteConcat byteConcat = new ByteConcat(3);
+        byteConcat.appendLong(0x10460E10L, 17);
+        assertArrayEquals(new byte[]{0x07, 0x08, 0x00}, byteConcat.getContent());
+    }
+
+    @Test
+    public void testAppendLong_negativeInteger_integerSize() {
+        ByteConcat byteConcat = new ByteConcat(3);
+        byteConcat.appendLong(-0x10460E10L, 17);
+        assertArrayEquals(new byte[]{(byte) 0xF8, (byte) 0xF8, 0x00}, byteConcat.getContent());
+    }
+
+    @Test
+    public void testAppendLong_positiveLong_integerSize() {
+        ByteConcat byteConcat = new ByteConcat(4);
+        byteConcat.appendLong(0x1896014701634004L, 25);
+        assertArrayEquals(new byte[]{
+                (byte) 0xB1, (byte) 0xA0, 0x02, 0x00
+        }, byteConcat.getContent());
+    }
+
+    @Test
+    public void testAppendLong_negativeLong_integerSize() {
+        ByteConcat byteConcat = new ByteConcat(4);
+        byteConcat.appendLong(-0x1896014701634004L, 25);
+        assertArrayEquals(new byte[]{
+                0x4E, 0x5F, (byte) 0xFE, 0x00
+        }, byteConcat.getContent());
+    }
+
+    @Test
+    public void testAppendLong_positiveLong_longSize() {
+        ByteConcat byteConcat = new ByteConcat(6);
+        byteConcat.appendLong(0x1896014701634004L, 43);
+        assertArrayEquals(new byte[]{
+                0x28, (byte) 0xE0, 0x2C, 0x68, 0x00, (byte) 0x80
+        }, byteConcat.getContent());
+    }
+
+    @Test
+    public void testAppendLong_negativeLong_longSize() {
+        ByteConcat byteConcat = new ByteConcat(6);
+        byteConcat.appendLong(-0x1896014701634004L, 43);
+        assertArrayEquals(new byte[]{
+                (byte) 0xD7, 0x1F, (byte) 0xD3, (byte) 0x97, (byte) 0xFF, (byte) 0x80
+        }, byteConcat.getContent());
+    }
+
+    @Test
+    public void testAppendLong_bucketExpanded() {
+        ByteConcat byteConcat = new ByteConcat(1);
+        byteConcat.appendLong(0x1896014701634004L, 64);
+        assertArrayEquals(new byte[]{
+                0x18, (byte) 0x96, 0x01, 0x47, 0x01, 0x63, 0x40, 0x04
+        }, byteConcat.getContent());
+        assertEquals(8, byteConcat.getBucketSize());
+    }
+}

--- a/location/src/test/java/akhoi/libs/mlct/tools/java/ResizeDoubleTest.java
+++ b/location/src/test/java/akhoi/libs/mlct/tools/java/ResizeDoubleTest.java
@@ -1,0 +1,154 @@
+package akhoi.libs.mlct.tools.java;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class ResizeDoubleTest {
+    @Test
+    public void testCompressDouble() {
+        long actual = ResizeDouble.compressDouble(3.14, 4, 31);
+        assertEquals(0x448F5C28FL, actual);
+    }
+
+    @Test
+    public void testCompressDouble_expSizeOne() {
+        long actual = ResizeDouble.compressDouble(56.18, 1, 20);
+        assertEquals(0x1C170AL, actual);
+    }
+
+    @Test
+    public void testCompressDouble_expSizeZero() {
+        long actual = ResizeDouble.compressDouble(56.18, 0, 20);
+        assertEquals(0x0C170AL, actual);
+    }
+
+    @Test
+    public void testCompressDouble_negativeExpSize() {
+        long actual = ResizeDouble.compressDouble(56.18, -8, 20);
+        assertEquals(0x0C170AL, actual);
+    }
+
+    @Test
+    public void testCompressDouble_sigSizeOne() {
+        long actual = ResizeDouble.compressDouble(56.18, 5, 1);
+        assertEquals(0x29L, actual);
+    }
+
+    @Test
+    public void testCompressDouble_sigSizeZero() {
+        long actual = ResizeDouble.compressDouble(56.18, 5, 0);
+        assertEquals(0x29L, actual);
+    }
+
+    @Test
+    public void testCompressDouble_negativeSigSize() {
+        long actual = ResizeDouble.compressDouble(56.18, 5, -3);
+        assertEquals(0x29L, actual);
+    }
+
+    @Test
+    public void testCompressDouble_positiveSubnormal() {
+        long actual = ResizeDouble.compressDouble(1.1508711201542864e-308, 5, 3);
+        assertEquals(0x4L, actual);
+    }
+
+    @Test
+    public void testCompressDouble_negativeSubnormal() {
+        long actual = ResizeDouble.compressDouble(-1.1508711201542864e-308, 5, 3);
+        assertEquals(0x104L, actual);
+    }
+
+    @Test
+    public void testCompressDouble_positiveInfinity() {
+        long actual = ResizeDouble.compressDouble(Double.POSITIVE_INFINITY, 3, 7);
+        assertEquals(0x380L, actual);
+    }
+
+    @Test
+    public void testCompressDouble_negativeInfinity() {
+        long actual = ResizeDouble.compressDouble(Double.NEGATIVE_INFINITY, 3, 7);
+        assertEquals(0x780L, actual);
+    }
+
+    @Test
+    public void testCompressDouble_positiveZero() {
+        long actual = ResizeDouble.compressDouble(0.0, 5, 2);
+        assertEquals(0L, actual);
+    }
+
+    @Test
+    public void testCompressDouble_negativeZero() {
+        long actual = ResizeDouble.compressDouble(-0.0, 5, 2);
+        assertEquals(0x80L, actual);
+    }
+
+    @Test
+    public void testExpandDouble_partialDoubleSize() {
+        double actual = ResizeDouble.expandDouble(0x448F5C28FL, 4, 31);
+        assertEquals(3.139999999664724, actual, 0.0);
+    }
+
+    @Test
+    public void testExpandDouble_fullDoubleSize() {
+        double actual = ResizeDouble.expandDouble(0x40091EB851EB851FL, 11, 52);
+        assertEquals(3.14, actual, 0.0);
+    }
+
+    @Test
+    public void testExpandDouble_zeroExpSize() {
+        double actual = ResizeDouble.expandDouble(0x0F8F5C28F5C29L, 0, 52);
+        assertEquals(Double.longBitsToDouble(0x4000F8F5C28F5C29L), actual, 0.0);
+    }
+
+    @Test
+    public void testResizeDouble_subnormal() {
+        long actual = ResizeDouble.resizeDouble(0x8C80029318421L, 11, 52, 3, 52);
+        assertEquals(0x8C80029318421L, actual);
+    }
+
+    @Test
+    public void testResizeDouble_NaN() {
+        long actual = ResizeDouble.resizeDouble(0x7FF0000000000001L, 11, 52, 5, 10);
+        assertEquals(0x7C00L, actual);
+    }
+
+    @Test
+    public void testResizeDouble_havingUnwantedLeadingBits() {
+        long actual = ResizeDouble.resizeDouble(0x0A0C0B4448F5C28FL, 4, 31, 11, 52);
+        assertEquals(0x40091EB851E00000L, actual);
+    }
+
+    @Test
+    public void testResizeDouble_unconventionalSizes_compression() {
+        long actual = ResizeDouble.resizeDouble(
+                0x0A0C0B4448F5C28FL,
+                4,
+                27,
+                1,
+                13
+        );
+        assertEquals(0x3D7L, actual);
+    }
+
+    @Test
+    public void testResizeDouble_unconventionalSizes_expansion() {
+        long actual = ResizeDouble.resizeDouble(
+                0x0A0C0B4448F5C28FL,
+                2,
+                7,
+                10,
+                30
+        );
+        assertEquals(0x17FC7800000L, actual);
+    }
+
+    @Test
+    public void testResizeDouble_compressAndExpand() {
+        long longVal = Double.doubleToRawLongBits(179.1357);
+        long compressed = ResizeDouble.resizeDouble(longVal, 11, 52, 4, 31);
+        long expanded = ResizeDouble.resizeDouble(compressed, 4, 31, 11, 52);
+        double doubleExpanded = Double.longBitsToDouble(expanded);
+        assertEquals(179.1356999874115, doubleExpanded, 0.0);
+    }
+}


### PR DESCRIPTION
## Summary
- add Java counterparts of the existing Kotlin byte concat and reader tests under `tools/java`
- mirror the Kotlin resize-double tests in Java so the Java wrappers are exercised

## Testing
- `./gradlew :location:test` *(fails: Android SDK not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d1fc7a15a08320a21c8d7477a6f3f3