### PR TITLE
Add CI workflow for pull request test execution

### DIFF
--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -1,4 +1,4 @@
-name: CI
+name: PR Checks
 
 on:
   pull_request:

--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   tests:
+    name: Unit Test
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+          cache: gradle
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Run tests
+        run: ./gradlew test


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that runs the Gradle test suite on pull requests targeting main
- configure Java 17 and Gradle caching for faster CI runs

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d210d224b08320b801bb38d01edab6